### PR TITLE
Refatora tela de lançamentos contábeis com grids de rateio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,10 @@ venv/
 db.sqlite3
 media/
 staticfiles/
-static/
+static/*
+!static/contabill/
+!static/contabill/js/
+!static/contabill/js/lancamentos.js
 
 # Env & IDE
 .env

--- a/contabill/urls.py
+++ b/contabill/urls.py
@@ -40,6 +40,9 @@ from .views.lancamentos import (
     LancamentoContabilUpdateView,
     LancamentoContabilDeleteView,
     RecalcularSaldoView,
+    LancamentoItemCreateView,
+    RateioCentroCustoView,
+    RateioProjetoView,
 )
 
 app_name = "contabill"
@@ -101,5 +104,30 @@ urlpatterns = [
         "lancamentos/recalcular-saldo/",
         RecalcularSaldoView.as_view(),
         name="lancamentos_recalcular_saldo",
+    ),
+    path(
+        "lancamentos/item/novo/",
+        LancamentoItemCreateView.as_view(),
+        name="lancamentos_item_create",
+    ),
+    path(
+        "lancamentos/rateio-cc/",
+        RateioCentroCustoView.as_view(),
+        name="lancamentos_rateio_cc",
+    ),
+    path(
+        "lancamentos/rateio-cc/salvar/",
+        RateioCentroCustoView.as_view(),
+        name="lancamentos_rateio_cc_save",
+    ),
+    path(
+        "lancamentos/rateio-projeto/",
+        RateioProjetoView.as_view(),
+        name="lancamentos_rateio_projeto",
+    ),
+    path(
+        "lancamentos/rateio-projeto/salvar/",
+        RateioProjetoView.as_view(),
+        name="lancamentos_rateio_projeto_save",
     ),
 ]

--- a/contabill/views/lancamentos.py
+++ b/contabill/views/lancamentos.py
@@ -2,13 +2,19 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render, get_object_or_404
 from django.urls import reverse_lazy
 from django.views import View
 from django.views.generic import ListView, CreateView, UpdateView, DeleteView
 
-from ..forms.lancamentos import LancamentoContabilForm, LancamentoItemFormSet
-from ..models import LancamentoContabil
+from ..forms.lancamentos import (
+    LancamentoContabilForm,
+    LancamentoItemForm,
+    LancamentoItemFormSet,
+    RateioCentroCustoFormSet,
+    RateioProjetoFormSet,
+)
+from ..models import LancamentoContabil, LancamentoItem
 from ..services.saldo import recalcular_saldos_por_periodo, recalcular_rateios_cc_projeto
 
 
@@ -26,28 +32,20 @@ class LancamentoContabilCreateView(LoginRequiredMixin, CreateView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        if self.request.POST:
-            ctx["itens_formset"] = LancamentoItemFormSet(self.request.POST, instance=self.object, prefix="itens")
-        else:
-            ctx["itens_formset"] = LancamentoItemFormSet(instance=self.object, prefix="itens")
+        base_instance = self.object if self.object else LancamentoContabil()
+        ctx["itens_formset"] = LancamentoItemFormSet(instance=base_instance, prefix="itens")
+        ctx["form_novo"] = LancamentoItemForm(prefix="novo")
         return ctx
 
     def form_valid(self, form):
-        context = self.get_context_data()
-        itens_formset = context["itens_formset"]
-        if not itens_formset.is_valid():
-            return self.form_invalid(form)
         with transaction.atomic():
             self.object = form.save()
-            itens_formset.instance = self.object
-            itens_formset.save()
             try:
                 self.object.validar()
             except ValidationError as exc:
                 form.add_error(None, exc)
                 transaction.set_rollback(True)
                 return self.form_invalid(form)
-            self.object.validar()
         messages.success(self.request, "Lançamento salvo com sucesso.")
         return super().form_valid(form)
 
@@ -71,4 +69,60 @@ class RecalcularSaldoView(LoginRequiredMixin, View):
         recalcular_rateios_cc_projeto(filial_id, periodo_id)
         messages.success(request, "Saldos recalculados.")
         return redirect("contabill:lancamentos_lista")
+
+
+class LancamentoItemCreateView(LoginRequiredMixin, View):
+    def post(self, request, *args, **kwargs):
+        lancamento = get_object_or_404(LancamentoContabil, pk=request.POST.get("lancamento_id"))
+        item_form = LancamentoItemForm(request.POST, prefix="novo")
+        cc_formset = RateioCentroCustoFormSet(request.POST, prefix="cc")
+        proj_formset = RateioProjetoFormSet(request.POST, prefix="projeto")
+        if item_form.is_valid() and cc_formset.is_valid() and proj_formset.is_valid():
+            item = item_form.save(commit=False)
+            item.lancamento = lancamento
+            item.filial = lancamento.filial
+            item.save()
+            cc_formset.instance = item
+            proj_formset.instance = item
+            cc_formset.save()
+            proj_formset.save()
+            try:
+                item.validar_rateios()
+            except ValidationError as exc:
+                item.delete()
+                item_form.add_error(None, exc)
+        itens_formset = LancamentoItemFormSet(instance=lancamento, prefix="itens")
+        context = {"formset": itens_formset, "form_novo": item_form if item_form.errors else LancamentoItemForm(prefix="novo")}
+        response = render(request, "contabill/lancamentos/_grid_itens.html", context)
+        if item_form.errors or cc_formset.non_form_errors() or proj_formset.non_form_errors():
+            response.status_code = 400
+        return response
+
+
+class RateioCentroCustoView(LoginRequiredMixin, View):
+    def get(self, request, *args, **kwargs):
+        item = get_object_or_404(LancamentoItem, pk=request.GET.get("item"))
+        formset = RateioCentroCustoFormSet(instance=item, prefix="cc")
+        return render(request, "contabill/lancamentos/_grid_cc.html", {"formset": formset, "item": item})
+
+    def post(self, request, *args, **kwargs):
+        item = get_object_or_404(LancamentoItem, pk=request.POST.get("item"))
+        formset = RateioCentroCustoFormSet(request.POST, instance=item, prefix="cc")
+        if formset.is_valid():
+            formset.save()
+        return render(request, "contabill/lancamentos/_grid_cc.html", {"formset": formset, "item": item})
+
+
+class RateioProjetoView(LoginRequiredMixin, View):
+    def get(self, request, *args, **kwargs):
+        item = get_object_or_404(LancamentoItem, pk=request.GET.get("item"))
+        formset = RateioProjetoFormSet(instance=item, prefix="projeto")
+        return render(request, "contabill/lancamentos/_grid_projeto.html", {"formset": formset, "item": item})
+
+    def post(self, request, *args, **kwargs):
+        item = get_object_or_404(LancamentoItem, pk=request.POST.get("item"))
+        formset = RateioProjetoFormSet(request.POST, instance=item, prefix="projeto")
+        if formset.is_valid():
+            formset.save()
+        return render(request, "contabill/lancamentos/_grid_projeto.html", {"formset": formset, "item": item})
 

--- a/static/contabill/js/lancamentos.js
+++ b/static/contabill/js/lancamentos.js
@@ -1,0 +1,51 @@
+(function(){
+  function parseValor(v){
+    if(!v) return 0;
+    if(typeof v === 'string'){
+      v = v.replace(/\./g,'').replace(',', '.');
+    }
+    var n = parseFloat(v);
+    return isNaN(n) ? 0 : n;
+  }
+  function format(v){
+    return v.toLocaleString('pt-BR', {minimumFractionDigits:2, maximumFractionDigits:2});
+  }
+  function recalc(){
+    var totalD=0, totalC=0;
+    document.querySelectorAll('#itens-body tr[data-item-id]').forEach(function(row){
+      var tipo = row.getAttribute('data-tipo');
+      var val = parseValor(row.getAttribute('data-valor'));
+      if(tipo === 'D') totalD += val; else if(tipo === 'C') totalC += val;
+    });
+    var dif = totalD - totalC;
+    document.getElementById('total-debito').textContent = format(totalD);
+    document.getElementById('total-credito').textContent = format(totalC);
+    document.getElementById('total-diferenca').textContent = format(dif);
+    var btn = document.getElementById('btn-salvar');
+    if(btn){ btn.disabled = Math.abs(dif) > 0.0001; }
+  }
+  function bindRows(){
+    document.querySelectorAll('#itens-body tr[data-item-id]').forEach(function(row){
+      row.addEventListener('click', function(){
+        document.querySelectorAll('#itens-body tr').forEach(function(r){r.classList.remove('table-active');});
+        row.classList.add('table-active');
+        var id = row.getAttribute('data-item-id');
+        var grid = document.getElementById('grid-itens');
+        var urlCC = grid.getAttribute('data-url-cc') + '?item=' + id;
+        var urlProj = grid.getAttribute('data-url-projeto') + '?item=' + id;
+        htmx.ajax('GET', urlCC, {target:'#grid-cc', swap:'outerHTML'});
+        htmx.ajax('GET', urlProj, {target:'#grid-projeto', swap:'outerHTML'});
+      });
+    });
+  }
+  document.addEventListener('htmx:afterSwap', function(ev){
+    if(ev.detail.target.id === 'grid-itens'){
+      bindRows();
+      recalc();
+    }
+  });
+  document.addEventListener('DOMContentLoaded', function(){
+    bindRows();
+    recalc();
+  });
+})();

--- a/templates/contabill/lancamentos/_grid_cc.html
+++ b/templates/contabill/lancamentos/_grid_cc.html
@@ -1,0 +1,33 @@
+{% if formset %}
+<form hx-post="{% url 'contabill:lancamentos_rateio_cc_save' %}" hx-target="#grid-cc" hx-swap="outerHTML">
+  <input type="hidden" name="item" value="{{ item.id }}">
+  {{ formset.management_form }}
+  <table class="table table-sm table-hover align-middle">
+    <thead class="table-light">
+      <tr>
+        <th>Centro de Custo</th>
+        <th class="text-end">Valor</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for f in formset.forms %}
+      <tr>
+        <td>{{ f.centro_custo }}{% for error in f.centro_custo.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}</td>
+        <td>{{ f.valor }}{% for error in f.valor.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}</td>
+        <td>{% if f.instance.pk %}<input type="checkbox" name="{{ f.prefix }}-DELETE" class="form-check-input">{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+    <tfoot>
+      <tr>
+        <td class="text-end">Total:</td>
+        <td><span id="total-cc">0,00</span></td>
+        <td><button class="btn btn-sm btn-primary">Salvar CC</button></td>
+      </tr>
+    </tfoot>
+  </table>
+</form>
+{% else %}
+<div class="border p-2">Selecione um item para rateio de Centro de Custo.</div>
+{% endif %}

--- a/templates/contabill/lancamentos/_grid_itens.html
+++ b/templates/contabill/lancamentos/_grid_itens.html
@@ -1,0 +1,62 @@
+<table class="table table-striped table-hover align-middle">
+  <thead class="table-light">
+    <tr>
+      <th>Conta</th>
+      <th>Histórico</th>
+      <th>Moeda</th>
+      <th>Tipo</th>
+      <th class="text-end">Valor</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody id="itens-body">
+    {% for f in formset.forms %}
+    <tr data-item-id="{{ f.instance.pk }}" data-tipo="{{ f.instance.tipo_dc }}" data-valor="{{ f.instance.valor }}" class="item-row">
+      <td>{{ f.instance.conta_contabil }}</td>
+      <td>{{ f.instance.historico }}</td>
+      <td>{{ f.instance.moeda }}</td>
+      <td>{{ f.instance.get_tipo_dc_display }}</td>
+      <td class="text-end">{{ f.instance.valor }}</td>
+      <td></td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="6" class="text-center">Nenhum item adicionado.</td></tr>
+    {% endfor %}
+    <tr id="linha-nova" hx-post="{% url 'contabill:lancamentos_item_create' %}" hx-target="#grid-itens" hx-swap="outerHTML" hx-include="#linha-nova, #grid-cc form, #grid-projeto form">
+      <td>
+        {{ form_novo.conta_contabil }}
+        {% for error in form_novo.conta_contabil.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+      </td>
+      <td>
+        {{ form_novo.historico }}
+        {% for error in form_novo.historico.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+      </td>
+      <td>
+        {{ form_novo.moeda }}
+        {% for error in form_novo.moeda.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+      </td>
+      <td>
+        {{ form_novo.tipo_dc }}
+        {% for error in form_novo.tipo_dc.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+      </td>
+      <td>
+        {{ form_novo.valor }}
+        {% for error in form_novo.valor.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+      </td>
+      <td>
+        <input type="hidden" name="lancamento_id" value="{{ formset.instance.pk }}">
+        <button class="btn btn-sm btn-primary">Adicionar</button>
+      </td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <th colspan="2" class="text-end">Total Débito:</th>
+      <th colspan="1"><span id="total-debito">0,00</span></th>
+      <th colspan="1" class="text-end">Total Crédito:</th>
+      <th colspan="1"><span id="total-credito">0,00</span></th>
+      <th colspan="1" class="text-end">Diferença:</th>
+      <th colspan="1"><span id="total-diferenca">0,00</span></th>
+    </tr>
+  </tfoot>
+</table>

--- a/templates/contabill/lancamentos/_grid_projeto.html
+++ b/templates/contabill/lancamentos/_grid_projeto.html
@@ -1,0 +1,33 @@
+{% if formset %}
+<form hx-post="{% url 'contabill:lancamentos_rateio_projeto_save' %}" hx-target="#grid-projeto" hx-swap="outerHTML">
+  <input type="hidden" name="item" value="{{ item.id }}">
+  {{ formset.management_form }}
+  <table class="table table-sm table-hover align-middle">
+    <thead class="table-light">
+      <tr>
+        <th>Projeto</th>
+        <th class="text-end">Valor</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for f in formset.forms %}
+      <tr>
+        <td>{{ f.projeto }}{% for error in f.projeto.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}</td>
+        <td>{{ f.valor }}{% for error in f.valor.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}</td>
+        <td>{% if f.instance.pk %}<input type="checkbox" name="{{ f.prefix }}-DELETE" class="form-check-input">{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+    <tfoot>
+      <tr>
+        <td class="text-end">Total:</td>
+        <td><span id="total-projeto">0,00</span></td>
+        <td><button class="btn btn-sm btn-primary">Salvar Projetos</button></td>
+      </tr>
+    </tfoot>
+  </table>
+</form>
+{% else %}
+<div class="border p-2">Selecione um item para rateio de Projeto.</div>
+{% endif %}

--- a/templates/contabill/lancamentos/form.html
+++ b/templates/contabill/lancamentos/form.html
@@ -5,32 +5,12 @@
 <div class="main-content">
   <div class="page-content">
     <div class="container-fluid">
-
-      {% block pagetitle %}{% include "partials/page-title.html" with pagetitle="Movimentação" title="Lançamento Contábil" %}{% endblock pagetitle %}
-
-      {% if messages %}
-        {% for message in messages %}
-          <div class="alert {{ message.tags }} alert-dismissible fade show" role="alert">
-            {{ message }}
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-          </div>
-        {% endfor %}
-      {% endif %}
-
+      {% include "partials/page-title.html" with pagetitle="Movimentação" title="Lançamento Contábil" %}
       <div class="card">
         <div class="card-body">
           <form method="post">
             {% csrf_token %}
-
-            {% if form.non_field_errors %}
-              <div class="alert alert-danger">{{ form.non_field_errors }}</div>
-            {% endif %}
-            {% if form.errors %}
-              <div class="alert alert-danger">Corrija os campos em destaque.</div>
-            {% endif %}
-            <div class="alert alert-danger" id="alert-desbalanceado" style="display:none;">Débitos e créditos não estão balanceados.</div>
-
-            <!-- Cabeçalho do lançamento -->
+            {% if form.non_field_errors %}<div class="alert alert-danger">{{ form.non_field_errors }}</div>{% endif %}
             <div class="row g-3">
               {% if form.data_lancamento %}
               <div class="col-md-3">
@@ -38,49 +18,36 @@
                 {% for error in form.data_lancamento.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
               </div>
               {% endif %}
-
               {% if form.data_competencia %}
               <div class="col-md-3">
                 {{ form.data_competencia.label_tag }}{{ form.data_competencia }}
                 {% for error in form.data_competencia.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
               </div>
               {% endif %}
-
               {% if form.filial %}
               <div class="col-md-3">
                 {{ form.filial.label_tag }}{{ form.filial }}
                 {% for error in form.filial.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
               </div>
               {% endif %}
-
               {% if form.numero_documento %}
               <div class="col-md-3">
                 {{ form.numero_documento.label_tag }}{{ form.numero_documento }}
                 {% for error in form.numero_documento.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
               </div>
               {% endif %}
-
               {% if form.tipo_lancamento %}
               <div class="col-md-3">
                 {{ form.tipo_lancamento.label_tag }}{{ form.tipo_lancamento }}
                 {% for error in form.tipo_lancamento.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
               </div>
               {% endif %}
-
               {% if form.origem %}
               <div class="col-md-3">
                 {{ form.origem.label_tag }}{{ form.origem }}
                 {% for error in form.origem.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
               </div>
               {% endif %}
-
-              {% if form.codigo_externo %}
-              <div class="col-md-3">
-                {{ form.codigo_externo.label_tag }}{{ form.codigo_externo }}
-                {% for error in form.codigo_externo.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-              </div>
-              {% endif %}
-
               {% if form.status %}
               <div class="col-md-3">
                 <div class="form-check mt-4">
@@ -90,7 +57,6 @@
                 {% for error in form.status.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
               </div>
               {% endif %}
-
               {% if form.descricao %}
               <div class="col-12">
                 {{ form.descricao.label_tag }}{{ form.descricao }}
@@ -98,151 +64,27 @@
               </div>
               {% endif %}
             </div>
-
             <hr class="my-4">
-
-            <!-- Itens (formset) -->
-            {% if itens_formset.non_form_errors %}
-              <div class="alert alert-danger">{{ itens_formset.non_form_errors }}</div>
-            {% endif %}
-
-            {{ itens_formset.management_form }}
-            <div class="table-responsive">
-              <table class="table table-striped table-hover align-middle">
-                <thead class="table-light">
-                  <tr>
-                    <th style="min-width:220px;">Conta Contábil</th>
-                    <th style="min-width:180px;">Histórico</th>
-                    <th style="min-width:120px;">Moeda</th>
-                    <th style="min-width:110px;">Tipo (D/C)</th>
-                    <th style="min-width:140px;">Valor</th>
-                    <th style="min-width:160px;">Filial</th>
-                    {% if itens_formset.empty_form.codigo_externo %}
-                      <th style="min-width:160px;">Cód. Externo</th>
-                    {% endif %}
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for f in itens_formset %}
-                    {% if f.non_field_errors %}
-                      <tr><td colspan="7"><div class="alert alert-danger my-2">{{ f.non_field_errors }}</div></td></tr>
-                    {% endif %}
-                    <tr>
-                      <td>
-                        {{ f.conta_contabil }}
-                        {% for error in f.conta_contabil.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                        {{ f.id }} {{ f.lancamento }}
-                      </td>
-                      <td>
-                        {{ f.historico }}
-                        {% for error in f.historico.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                      </td>
-                      <td>
-                        {{ f.moeda }}
-                        {% for error in f.moeda.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                      </td>
-                      <td style="max-width:120px;">
-                        {{ f.tipo_dc }}
-                        {% for error in f.tipo_dc.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                      </td>
-                      <td style="max-width:160px;">
-                        {{ f.valor }}
-                        {% for error in f.valor.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                      </td>
-                      <td>
-                        {{ f.filial }}
-                        {% for error in f.filial.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                      </td>
-                      {% if f.codigo_externo %}
-                      <td>
-                        {{ f.codigo_externo }}
-                        {% for error in f.codigo_externo.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                      </td>
-                      {% endif %}
-                    </tr>
-                  {% endfor %}
-                </tbody>
-                <tfoot>
-                  <tr>
-                    <th colspan="3" class="text-end">Total Débito:</th>
-                    <th colspan="1"><span id="total-debito">R$ 0,00</span></th>
-                    <th colspan="1" class="text-end">Total Crédito:</th>
-                    <th colspan="1"><span id="total-credito">R$ 0,00</span></th>
-                    <th colspan="1" class="text-end">Diferença:</th>
-                    <th colspan="1"><span id="total-diferenca">R$ 0,00</span></th>
-                  </tr>
-                </tfoot>
-              </table>
+            <div id="grid-itens" data-url-cc="{% url 'contabill:lancamentos_rateio_cc' %}" data-url-projeto="{% url 'contabill:lancamentos_rateio_projeto' %}" hx-swap="outerHTML">
+              {% include "contabill/lancamentos/_grid_itens.html" with formset=itens_formset form_novo=form_novo %}
             </div>
-
-            <div class="mt-3 d-flex justify-content-between">
-              <div>
-                <button type="submit" class="btn btn-success" id="btn-salvar">Salvar</button>
-                <a href="{% url 'contabill:lancamentos_lista' %}" class="btn btn-secondary">Cancelar</a>
+            <div class="row mt-4">
+              <div class="col-md-6" id="grid-cc" hx-swap="outerHTML">
+                {% include "contabill/lancamentos/_grid_cc.html" with formset=None %}
+              </div>
+              <div class="col-md-6" id="grid-projeto" hx-swap="outerHTML">
+                {% include "contabill/lancamentos/_grid_projeto.html" with formset=None %}
               </div>
             </div>
-
+            <div class="mt-3">
+              <button type="submit" class="btn btn-success" id="btn-salvar" disabled>Salvar</button>
+              <a href="{% url 'contabill:lancamentos_lista' %}" class="btn btn-secondary">Cancelar</a>
+            </div>
           </form>
         </div>
       </div>
-
     </div>
   </div>
 </div>
-<script>
-(function(){
-  function parseValor(v){
-    if(!v) return 0;
-    v = v.replace(/\./g,'').replace(',', '.');
-    var n = Number(v);
-    return isNaN(n) ? 0 : n;
-  }
-  function recalc(){
-    var totalD = 0, totalC = 0;
-    const linhas = document.querySelectorAll('input[name$="-valor"]').length;
-    for (let i=0; i<linhas; i++){
-      const del = document.querySelector('input[name="itens-' + i + '-DELETE"]');
-      if (del && del.checked) continue;
-
-      const tipo = document.querySelector('select[name="itens-' + i + '-tipo_dc"]');
-      const val  = document.querySelector('input[name="itens-' + i + '-valor"]');
-      if(!tipo || !val) continue;
-
-      const num = parseValor(val.value);
-      if (tipo.value === 'D') totalD += num;
-      else if (tipo.value === 'C') totalC += num;
-    }
-    const dif = (totalD - totalC);
-    const fmt = (n)=> n.toLocaleString('pt-BR', {style:'currency', currency:'BRL'});
-    document.getElementById('total-debito').textContent   = fmt(totalD);
-    document.getElementById('total-credito').textContent  = fmt(totalC);
-    document.getElementById('total-diferenca').textContent= fmt(dif);
-
-    const alerta = document.getElementById('alert-desbalanceado');
-    const btnSalvar = document.getElementById('btn-salvar');
-    if (Math.abs(dif) > 0.000001){
-      if (alerta) alerta.style.display = '';
-      if (btnSalvar) btnSalvar.disabled = true;
-    } else {
-      if (alerta) alerta.style.display = 'none';
-      if (btnSalvar) btnSalvar.disabled = false;
-    }
-  }
-
-  function bind(){
-    const container = document;
-    container.addEventListener('input', function(ev){
-      const name = ev.target.name || '';
-      if (name.endsWith('-valor')) recalc();
-    });
-    container.addEventListener('change', function(ev){
-      const name = ev.target.name || '';
-      if (name.endsWith('-tipo_dc') || name.endsWith('-DELETE')) recalc();
-    });
-    recalc();
-  }
-  document.addEventListener('DOMContentLoaded', bind);
-})();
-</script>
+<script src="{% static 'contabill/js/lancamentos.js' %}"></script>
 {% endblock content %}
-


### PR DESCRIPTION
## Summary
- remove campos não utilizados e aplica valores padrão nos formulários de lançamentos
- adiciona endpoints e templates HTMX para itens, centros de custo e projetos
- inclui javascript para cálculo de totais e carregamento dinâmico dos rateios

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5433 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689a7f3c88348330903fa1fd975d6786