### PR TITLE
Enable HTMX item addition in lancamentos

### DIFF
--- a/contabill/tests/test_lancamentos_hx.py
+++ b/contabill/tests/test_lancamentos_hx.py
@@ -1,0 +1,40 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.test import Client
+from django.utils import timezone
+from contabill.models import (
+    LancamentoContabil, LancamentoItem, ContaContabil,
+    HistoricoPadrao, Filial, Moeda
+)
+
+
+@pytest.mark.django_db
+def test_hx_add_item_updates_grid(client: Client):
+    user = User.objects.create_user("u", password="p")
+    client.login(username="u", password="p")
+
+    filial = Filial.objects.create(nome="Matriz")
+    moeda = Moeda.objects.create(codigo="1", nome="REAL")
+    conta = ContaContabil.objects.create(codigo="1.01", descricao="Conta teste", classificacao="A", natureza="D", status=True)
+    hist = HistoricoPadrao.objects.create(descricao="LANÇAMENTOS")
+
+    lanc = LancamentoContabil.objects.create(
+        data_lancamento=timezone.localdate(),
+        data_competencia=timezone.localdate(),
+        filial=filial, usuario=user, tipo_lancamento="0", origem="0", status=True
+    )
+
+    url = reverse("contabill:lancamentos_item_create")
+    resp = client.post(url, data={
+        "lancamento_id": lanc.id,
+        "novo-conta_contabil": conta.id,
+        "novo-historico": hist.id,
+        "novo-moeda": moeda.id,
+        "novo-tipo_dc": "D",
+        "novo-valor": "100,00",
+    }, HTTP_HX_REQUEST="true")
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert "Conta teste" in html
+    assert LancamentoItem.objects.filter(lancamento=lanc).count() == 1

--- a/contabill/urls.py
+++ b/contabill/urls.py
@@ -40,7 +40,7 @@ from .views.lancamentos import (
     LancamentoContabilUpdateView,
     LancamentoContabilDeleteView,
     RecalcularSaldoView,
-    LancamentoItemCreateView,
+    LancamentoItemCreateHX,
     RateioCentroCustoView,
     RateioProjetoView,
 )
@@ -107,7 +107,7 @@ urlpatterns = [
     ),
     path(
         "lancamentos/item/novo/",
-        LancamentoItemCreateView.as_view(),
+        LancamentoItemCreateHX.as_view(),
         name="lancamentos_item_create",
     ),
     path(

--- a/static/contabill/js/lancamentos.js
+++ b/static/contabill/js/lancamentos.js
@@ -38,14 +38,11 @@
       });
     });
   }
-  document.addEventListener('htmx:afterSwap', function(ev){
-    if(ev.detail.target.id === 'grid-itens'){
-      bindRows();
-      recalc();
-    }
-  });
-  document.addEventListener('DOMContentLoaded', function(){
+  window.recalcLancamentos = function(){
     bindRows();
     recalc();
+  };
+  document.addEventListener('DOMContentLoaded', function(){
+    window.recalcLancamentos();
   });
 })();

--- a/templates/contabill/lancamentos/_grid_cc.html
+++ b/templates/contabill/lancamentos/_grid_cc.html
@@ -1,5 +1,5 @@
 {% if formset %}
-<form hx-post="{% url 'contabill:lancamentos_rateio_cc_save' %}" hx-target="#grid-cc" hx-swap="outerHTML">
+<form id="form-cc" hx-post="{% url 'contabill:lancamentos_rateio_cc_save' %}" hx-target="#grid-cc" hx-swap="outerHTML">
   <input type="hidden" name="item" value="{{ item.id }}">
   {{ formset.management_form }}
   <table class="table table-sm table-hover align-middle">

--- a/templates/contabill/lancamentos/_grid_itens.html
+++ b/templates/contabill/lancamentos/_grid_itens.html
@@ -22,30 +22,38 @@
     {% empty %}
     <tr><td colspan="6" class="text-center">Nenhum item adicionado.</td></tr>
     {% endfor %}
-    <tr id="linha-nova" hx-post="{% url 'contabill:lancamentos_item_create' %}" hx-target="#grid-itens" hx-swap="outerHTML" hx-include="#linha-nova, #grid-cc form, #grid-projeto form">
+    <tr id="linha-nova">
       <td>
         {{ form_novo.conta_contabil }}
-        {% for error in form_novo.conta_contabil.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+        {% for e in form_novo.conta_contabil.errors %}<div class="invalid-feedback d-block">{{ e }}</div>{% endfor %}
       </td>
       <td>
         {{ form_novo.historico }}
-        {% for error in form_novo.historico.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+        {% for e in form_novo.historico.errors %}<div class="invalid-feedback d-block">{{ e }}</div>{% endfor %}
       </td>
       <td>
         {{ form_novo.moeda }}
-        {% for error in form_novo.moeda.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+        {% for e in form_novo.moeda.errors %}<div class="invalid-feedback d-block">{{ e }}</div>{% endfor %}
       </td>
       <td>
         {{ form_novo.tipo_dc }}
-        {% for error in form_novo.tipo_dc.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+        {% for e in form_novo.tipo_dc.errors %}<div class="invalid-feedback d-block">{{ e }}</div>{% endfor %}
       </td>
       <td>
         {{ form_novo.valor }}
-        {% for error in form_novo.valor.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+        {% for e in form_novo.valor.errors %}<div class="invalid-feedback d-block">{{ e }}</div>{% endfor %}
       </td>
-      <td>
+      <td class="text-end">
         <input type="hidden" name="lancamento_id" value="{{ formset.instance.pk }}">
-        <button class="btn btn-sm btn-primary">Adicionar</button>
+        <button
+          type="button"
+          class="btn btn-sm btn-primary"
+          hx-post="{% url 'contabill:lancamentos_item_create' %}"
+          hx-target="#grid-itens"
+          hx-swap="innerHTML"
+          hx-include="#linha-nova, #form-cc, #form-projeto, input[name='csrfmiddlewaretoken']">
+          Adicionar
+        </button>
       </td>
     </tr>
   </tbody>

--- a/templates/contabill/lancamentos/_grid_projeto.html
+++ b/templates/contabill/lancamentos/_grid_projeto.html
@@ -1,5 +1,5 @@
 {% if formset %}
-<form hx-post="{% url 'contabill:lancamentos_rateio_projeto_save' %}" hx-target="#grid-projeto" hx-swap="outerHTML">
+<form id="form-projeto" hx-post="{% url 'contabill:lancamentos_rateio_projeto_save' %}" hx-target="#grid-projeto" hx-swap="outerHTML">
   <input type="hidden" name="item" value="{{ item.id }}">
   {{ formset.management_form }}
   <table class="table table-sm table-hover align-middle">

--- a/templates/contabill/lancamentos/form.html
+++ b/templates/contabill/lancamentos/form.html
@@ -65,26 +65,35 @@
               {% endif %}
             </div>
             <hr class="my-4">
-            <div id="grid-itens" data-url-cc="{% url 'contabill:lancamentos_rateio_cc' %}" data-url-projeto="{% url 'contabill:lancamentos_rateio_projeto' %}" hx-swap="outerHTML">
+            <div id="grid-itens"
+                 data-url-cc="{% url 'contabill:lancamentos_rateio_cc' %}"
+                 data-url-projeto="{% url 'contabill:lancamentos_rateio_projeto' %}">
               {% include "contabill/lancamentos/_grid_itens.html" with formset=itens_formset form_novo=form_novo %}
-            </div>
-            <div class="row mt-4">
-              <div class="col-md-6" id="grid-cc" hx-swap="outerHTML">
-                {% include "contabill/lancamentos/_grid_cc.html" with formset=None %}
-              </div>
-              <div class="col-md-6" id="grid-projeto" hx-swap="outerHTML">
-                {% include "contabill/lancamentos/_grid_projeto.html" with formset=None %}
-              </div>
             </div>
             <div class="mt-3">
               <button type="submit" class="btn btn-success" id="btn-salvar" disabled>Salvar</button>
               <a href="{% url 'contabill:lancamentos_lista' %}" class="btn btn-secondary">Cancelar</a>
             </div>
           </form>
+          <div class="row mt-4">
+            <div class="col-md-6" id="grid-cc" hx-swap="outerHTML">
+              {% include "contabill/lancamentos/_grid_cc.html" with formset=None %}
+            </div>
+            <div class="col-md-6" id="grid-projeto" hx-swap="outerHTML">
+              {% include "contabill/lancamentos/_grid_projeto.html" with formset=None %}
+            </div>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </div>
 <script src="{% static 'contabill/js/lancamentos.js' %}"></script>
+<script>
+document.body.addEventListener("htmx:afterSwap", function (evt) {
+  if (evt.target.id === "grid-itens" && typeof window.recalcLancamentos === "function") {
+    window.recalcLancamentos();
+  }
+});
+</script>
 {% endblock content %}

--- a/templates/partials/base.html
+++ b/templates/partials/base.html
@@ -68,6 +68,15 @@
     <script src="{% static 'js/app.js'%}"></script>
     {% endblock javascript %}
 
+    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+    <script>
+      // Envia o CSRF em todos os hx-requests
+      document.body.addEventListener("htmx:configRequest", function (evt) {
+        const t = document.querySelector('input[name="csrfmiddlewaretoken"]');
+        if (t) evt.detail.headers["X-CSRFToken"] = t.value;
+      });
+    </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- load HTMX globally and send CSRF token on every request
- swap item grid via new HX view and unique prefixes for rateio forms
- expose recalcLancamentos helper and provide HX test for item creation

## Testing
- `pytest` *(fails: Apps aren't loaded yet)*
- `pip install pytest-django` *(fails: Could not find a version that satisfies the requirement pytest-django)*

------
https://chatgpt.com/codex/tasks/task_e_689a8c3fa5508330a9af674c370ae46b